### PR TITLE
Update to Snapraid 12.0 & Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:buster
+FROM debian:bullseye
 MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
 ARG SNAPRAID_VERSION="11.6"
 
 # Builds SnapRAID from source
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list && \
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list && \
       apt update && \
       apt install -y \
         gcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye
 MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
-ARG SNAPRAID_VERSION="11.6"
+ARG SNAPRAID_VERSION="12.0"
 
 # Builds SnapRAID from source
 RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list && \


### PR DESCRIPTION
Hello there 👋️

I am a big fan of the self-hosted.show podcast and have been using a lot of the suggested tools to grow my homelab.  One of these is snapraid, which is prominently featured in the perfectmediaserver wiki.  This docker repo has been awesome for building the snapraid updates, since it doesn't clutter my main server with build tools.

I noticed it hadn't yet been updated to publish Snapraid v12.0 yet, and I also noticed it was still using buster during the docker builds.  So, I figured I would try to give back a bit by updating both of those things.  This should build a Snapraid 12.0 deb file using Debian Bullseye.