### PR TITLE
Make Less Dependent on Source Repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - "*"
+      - master
   pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -23,10 +25,3 @@ jobs:
         run: |
           ls -la build/
           ls -la
-
-      - name: Store archives
-        uses: actions/upload-artifact@v2
-        with:
-          name: snapraid-deb.zip
-          path: build/*.deb
-          if-no-files-found: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian
-MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
 ARG SNAPRAID_VERSION
 


### PR DESCRIPTION
Change some things to help distinguish this fork from the source.  Don't include a maintainer to avoid confusion & don't store build artifacts.